### PR TITLE
fix: Add warn log for create/update interval

### DIFF
--- a/internal/core/metadata/application/device.go
+++ b/internal/core/metadata/application/device.go
@@ -69,12 +69,7 @@ func AddDevice(d models.Device, ctx context.Context, dic *di.Container) (id stri
 
 	// If device is successfully created, check each AutoEvent interval value and display a warning if it's smaller than the suggested 10ms value
 	for _, autoEvent := range d.AutoEvents {
-		valid, err := utils.CheckDuration(autoEvent.Interval, minAutoEventInterval)
-		if err != nil {
-			lc.Warnf("failed to check auto event interval: %v", err)
-		} else if !valid {
-			lc.Warnf("the interval value '%s' is smaller than the suggested value '%s', which might cause abnormal CPU increase", autoEvent.Interval, minAutoEventInterval)
-		}
+		utils.CheckMinInterval(autoEvent.Interval, minAutoEventInterval, lc)
 	}
 
 	deviceDTO := dtos.FromDeviceModelToDTO(addedDevice)
@@ -178,12 +173,7 @@ func PatchDevice(dto dtos.UpdateDevice, ctx context.Context, dic *di.Container) 
 
 	// If device is successfully updated, check each AutoEvent interval value and display a warning if it's smaller than the suggested 10ms value
 	for _, autoEvent := range device.AutoEvents {
-		valid, err := utils.CheckDuration(autoEvent.Interval, minAutoEventInterval)
-		if err != nil {
-			lc.Warnf("failed to check auto event interval: %v", err)
-		} else if !valid {
-			lc.Warnf("the interval value '%s' is smaller than the suggested value '%s', which might cause abnormal CPU increase", autoEvent.Interval, minAutoEventInterval)
-		}
+		utils.CheckMinInterval(autoEvent.Interval, minAutoEventInterval, lc)
 	}
 
 	lc.Debugf(

--- a/internal/pkg/utils/time.go
+++ b/internal/pkg/utils/time.go
@@ -6,27 +6,29 @@
 package utils
 
 import (
-	"fmt"
 	"time"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/v3/errors"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
 )
 
-// CheckDuration parses the ISO 8601 time duration string to Duration type
+// CheckMinInterval parses the ISO 8601 time duration string to Duration type
 // and evaluates if the duration value is smaller than the suggested minimum duration string
-func CheckDuration(value string, min string) (bool, errors.EdgeX) {
+func CheckMinInterval(value string, min string, lc logger.LoggingClient) bool {
 	valueDuration, err := time.ParseDuration(value)
 	if err != nil {
-		return false, errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("failed to parse the interval duration string %s to a duration time value", value), err)
+		lc.Errorf("failed to parse the interval duration string %s to a duration time value: %v", value, err)
+		return false
 	}
 	minDuration, err := time.ParseDuration(min)
 	if err != nil {
-		return false, errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("failed to parse the minimum duration string %s to a duration time value", min), err)
+		lc.Errorf("failed to parse the  minimum duration string %s to a duration time value: %v", value, err)
+		return false
 	}
 
 	if valueDuration < minDuration {
 		// the duration value is smaller than the min
-		return false, nil
+		lc.Warnf("the interval value '%s' is smaller than the suggested value '%s', which might cause abnormal CPU increase", valueDuration, minDuration)
+		return false
 	}
-	return true, nil
+	return true
 }

--- a/internal/pkg/utils/time.go
+++ b/internal/pkg/utils/time.go
@@ -1,0 +1,32 @@
+//
+// Copyright (C) 2023 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/errors"
+)
+
+// CheckDuration parses the ISO 8601 time duration string to Duration type
+// and evaluates if the duration value is smaller than the suggested minimum duration string
+func CheckDuration(value string, min string) (bool, errors.EdgeX) {
+	valueDuration, err := time.ParseDuration(value)
+	if err != nil {
+		return false, errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("failed to parse the interval duration string %s to a duration time value", value), err)
+	}
+	minDuration, err := time.ParseDuration(min)
+	if err != nil {
+		return false, errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("failed to parse the minimum duration string %s to a duration time value", min), err)
+	}
+
+	if valueDuration < minDuration {
+		// the duration value is smaller than the min
+		return false, nil
+	}
+	return true, nil
+}

--- a/internal/pkg/utils/time_test.go
+++ b/internal/pkg/utils/time_test.go
@@ -1,0 +1,42 @@
+//
+// Copyright (C) 2023 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/errors"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckDuration(t *testing.T) {
+	tests := []struct {
+		name            string
+		interval        string
+		min             string
+		result          bool
+		errorExpected   bool
+		expectedErrKind errors.ErrKind
+	}{
+		{"valid - interval is bigger than the minimum value", "1s", "10ms", true, false, ""},
+		{"invalid - interval is bigger than the minimum value", "100us", "1ms", false, false, ""},
+		{"invalid - parsing duration string failed", "INVALID", "1ms", false, true, errors.KindServerError},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := CheckDuration(tt.interval, tt.min)
+			if tt.errorExpected {
+				assert.Error(t, err)
+				assert.NotEmpty(t, err.Error(), "Error message is empty")
+				assert.Equal(t, tt.expectedErrKind, errors.Kind(err), "Error kind not as expected")
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.result, result)
+			}
+		})
+	}
+}

--- a/internal/pkg/utils/time_test.go
+++ b/internal/pkg/utils/time_test.go
@@ -8,35 +8,28 @@ package utils
 import (
 	"testing"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/v3/errors"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCheckDuration(t *testing.T) {
+func TestCheckMinInterval(t *testing.T) {
+	lc := logger.NewMockClient()
+
 	tests := []struct {
-		name            string
-		interval        string
-		min             string
-		result          bool
-		errorExpected   bool
-		expectedErrKind errors.ErrKind
+		name     string
+		interval string
+		min      string
+		result   bool
 	}{
-		{"valid - interval is bigger than the minimum value", "1s", "10ms", true, false, ""},
-		{"invalid - interval is bigger than the minimum value", "100us", "1ms", false, false, ""},
-		{"invalid - parsing duration string failed", "INVALID", "1ms", false, true, errors.KindServerError},
+		{"valid - interval is bigger than the minimum value", "1s", "10ms", true},
+		{"invalid - interval is smaller than the minimum value", "100us", "1ms", false},
+		{"invalid - parsing duration string failed", "INVALID", "1ms", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := CheckDuration(tt.interval, tt.min)
-			if tt.errorExpected {
-				assert.Error(t, err)
-				assert.NotEmpty(t, err.Error(), "Error message is empty")
-				assert.Equal(t, tt.expectedErrKind, errors.Kind(err), "Error kind not as expected")
-			} else {
-				assert.NoError(t, err)
-				assert.Equal(t, tt.result, result)
-			}
+			result := CheckMinInterval(tt.interval, tt.min, lc)
+			assert.Equal(t, tt.result, result)
 		})
 	}
 }

--- a/internal/support/scheduler/application/interval.go
+++ b/internal/support/scheduler/application/interval.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2021 IOTech Ltd
+// Copyright (C) 2021-2023 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -10,6 +10,7 @@ import (
 	"fmt"
 
 	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/utils"
 	"github.com/edgexfoundry/edgex-go/internal/support/scheduler/container"
 	"github.com/edgexfoundry/edgex-go/internal/support/scheduler/infrastructure/interfaces"
 
@@ -21,6 +22,9 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/errors"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/models"
 )
+
+// the suggested minimum duration string for scheduler interval
+const minSchedulerInterval = "10ms"
 
 // The AddInterval function accepts the new Interval model from the controller function
 // and then invokes AddInterval function of infrastructure layer to add new Interval
@@ -40,6 +44,14 @@ func AddInterval(interval models.Interval, ctx context.Context, dic *di.Containe
 	lc.Debugf("Interval created on DB successfully. Interval ID: %s, Correlation-ID: %s ",
 		addedInterval.Id,
 		correlation.FromContext(ctx))
+
+	// If interval is successfully created, check the interval value and display a warning if it's smaller than the suggested 10ms value
+	valid, err := utils.CheckDuration(interval.Interval, minSchedulerInterval)
+	if err != nil {
+		lc.Warnf("failed to check scheduler interval: %v", err)
+	} else if !valid {
+		lc.Warnf("the interval value '%s' is smaller than the suggested value '%s', which might cause abnormal CPU increase", interval.Interval, minSchedulerInterval)
+	}
 
 	return addedInterval.Id, nil
 }
@@ -114,6 +126,14 @@ func PatchInterval(dto dtos.UpdateInterval, ctx context.Context, dic *di.Contain
 	err = schedulerManager.UpdateInterval(interval)
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)
+	}
+
+	// If interval is successfully updated, check the interval value and display a warning if it's smaller than the suggested 10ms value
+	valid, err := utils.CheckDuration(interval.Interval, minSchedulerInterval)
+	if err != nil {
+		lc.Warnf("failed to check scheduler interval: %v", err)
+	} else if !valid {
+		lc.Warnf("the interval value '%s' is smaller than the suggested value '%s', which might cause abnormal CPU increase", interval.Interval, minSchedulerInterval)
 	}
 
 	lc.Debugf(

--- a/internal/support/scheduler/application/interval.go
+++ b/internal/support/scheduler/application/interval.go
@@ -46,12 +46,7 @@ func AddInterval(interval models.Interval, ctx context.Context, dic *di.Containe
 		correlation.FromContext(ctx))
 
 	// If interval is successfully created, check the interval value and display a warning if it's smaller than the suggested 10ms value
-	valid, err := utils.CheckDuration(interval.Interval, minSchedulerInterval)
-	if err != nil {
-		lc.Warnf("failed to check scheduler interval: %v", err)
-	} else if !valid {
-		lc.Warnf("the interval value '%s' is smaller than the suggested value '%s', which might cause abnormal CPU increase", interval.Interval, minSchedulerInterval)
-	}
+	utils.CheckMinInterval(interval.Interval, minSchedulerInterval, lc)
 
 	return addedInterval.Id, nil
 }
@@ -129,12 +124,7 @@ func PatchInterval(dto dtos.UpdateInterval, ctx context.Context, dic *di.Contain
 	}
 
 	// If interval is successfully updated, check the interval value and display a warning if it's smaller than the suggested 10ms value
-	valid, err := utils.CheckDuration(interval.Interval, minSchedulerInterval)
-	if err != nil {
-		lc.Warnf("failed to check scheduler interval: %v", err)
-	} else if !valid {
-		lc.Warnf("the interval value '%s' is smaller than the suggested value '%s', which might cause abnormal CPU increase", interval.Interval, minSchedulerInterval)
-	}
+	utils.CheckMinInterval(interval.Interval, minSchedulerInterval, lc)
 
 	lc.Debugf(
 		"Interval patched on DB successfully. Correlation-ID: %s ",


### PR DESCRIPTION
Add warn log for interval value from Interval and AutoEvent if the value is too small.

Closes #4586.